### PR TITLE
Add Metal triangle rendering app in Swift

### DIFF
--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -6,3 +6,5 @@ project(test_app)
 add_executable(test_app quasi.cpp)
 
 target_link_libraries(test_app PRIVATE glfw)
+
+# Metal Triangle App - build separately with: swiftc -o metal_triangle metal_triangle.swift -framework Cocoa -framework Metal -framework MetalKit

--- a/src/apps/Info.plist
+++ b/src/apps/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>metal_triangle</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.quasi.metal-triangle</string>
+    <key>CFBundleName</key>
+    <string>Metal Triangle</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/src/apps/metal_triangle.swift
+++ b/src/apps/metal_triangle.swift
@@ -1,0 +1,163 @@
+import Cocoa
+import Metal
+import MetalKit
+
+class TriangleRenderer: NSObject, MTKViewDelegate {
+    private var device: MTLDevice!
+    private var commandQueue: MTLCommandQueue!
+    private var renderPipelineState: MTLRenderPipelineState!
+    private var vertexBuffer: MTLBuffer!
+    
+    struct Vertex {
+        let position: SIMD3<Float>
+        let color: SIMD3<Float>
+    }
+    
+    private let vertices: [Vertex] = [
+        Vertex(position: SIMD3<Float>(0.0, 0.5, 0.0), color: SIMD3<Float>(1.0, 0.0, 0.0)),   // Top - Red
+        Vertex(position: SIMD3<Float>(-0.5, -0.5, 0.0), color: SIMD3<Float>(0.0, 1.0, 0.0)), // Bottom left - Green  
+        Vertex(position: SIMD3<Float>(0.5, -0.5, 0.0), color: SIMD3<Float>(0.0, 0.0, 1.0))   // Bottom right - Blue
+    ]
+    
+    init(device: MTLDevice) {
+        self.device = device
+        super.init()
+        
+        setupMetal()
+    }
+    
+    private func setupMetal() {
+        commandQueue = device.makeCommandQueue()
+        
+        // Create vertex buffer
+        let vertexDataSize = vertices.count * MemoryLayout<Vertex>.size
+        vertexBuffer = device.makeBuffer(bytes: vertices, length: vertexDataSize, options: [])
+        
+        // Create render pipeline using embedded shaders
+        let source = """
+        #include <metal_stdlib>
+        using namespace metal;
+        
+        struct VertexIn {
+            float3 position [[attribute(0)]];
+            float3 color [[attribute(1)]];
+        };
+        
+        struct VertexOut {
+            float4 position [[position]];
+            float3 color;
+        };
+        
+        vertex VertexOut vertex_main(const device VertexIn* vertices [[buffer(0)]],
+                                    uint vertexId [[vertex_id]]) {
+            VertexOut out;
+            VertexIn in = vertices[vertexId];
+            
+            out.position = float4(in.position, 1.0);
+            out.color = in.color;
+            
+            return out;
+        }
+        
+        fragment float4 fragment_main(VertexOut in [[stage_in]]) {
+            return float4(in.color, 1.0);
+        }
+        """
+        
+        guard let library = try? device.makeLibrary(source: source, options: nil) else {
+            fatalError("Failed to create Metal library")
+        }
+        
+        let vertexFunction = library.makeFunction(name: "vertex_main")
+        let fragmentFunction = library.makeFunction(name: "fragment_main")
+        
+        // Create vertex descriptor
+        let vertexDescriptor = MTLVertexDescriptor()
+        vertexDescriptor.attributes[0].format = .float3
+        vertexDescriptor.attributes[0].offset = 0
+        vertexDescriptor.attributes[0].bufferIndex = 0
+        
+        vertexDescriptor.attributes[1].format = .float3
+        vertexDescriptor.attributes[1].offset = MemoryLayout<SIMD3<Float>>.size
+        vertexDescriptor.attributes[1].bufferIndex = 0
+        
+        vertexDescriptor.layouts[0].stride = MemoryLayout<Vertex>.size
+        
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.vertexFunction = vertexFunction
+        pipelineDescriptor.fragmentFunction = fragmentFunction
+        pipelineDescriptor.vertexDescriptor = vertexDescriptor
+        pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+        
+        do {
+            renderPipelineState = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+        } catch {
+            fatalError("Failed to create render pipeline state: \(error)")
+        }
+    }
+    
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        // Handle resize if needed
+    }
+    
+    func draw(in view: MTKView) {
+        guard let drawable = view.currentDrawable,
+              let renderPassDescriptor = view.currentRenderPassDescriptor else {
+            return
+        }
+        
+        let commandBuffer = commandQueue.makeCommandBuffer()!
+        let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor)!
+        
+        renderEncoder.setRenderPipelineState(renderPipelineState)
+        renderEncoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        renderEncoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 3)
+        renderEncoder.endEncoding()
+        
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var window: NSWindow!
+    var metalView: MTKView!
+    var renderer: TriangleRenderer!
+    
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Create window
+        let windowRect = NSRect(x: 100, y: 100, width: 800, height: 600)
+        window = NSWindow(contentRect: windowRect,
+                         styleMask: [.titled, .closable, .resizable],
+                         backing: .buffered,
+                         defer: false)
+        window.title = "Metal Triangle"
+        window.center()
+        
+        // Setup Metal view
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            fatalError("Metal is not supported on this device")
+        }
+        
+        metalView = MTKView(frame: windowRect, device: device)
+        metalView.clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+        
+        renderer = TriangleRenderer(device: device)
+        metalView.delegate = renderer
+        
+        window.contentView = metalView
+        window.makeKeyAndOrderFront(nil)
+        
+        NSApp.activate(ignoringOtherApps: true)
+    }
+    
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return true
+    }
+}
+
+// Create and run the app
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/src/apps/shaders.metal
+++ b/src/apps/shaders.metal
@@ -1,0 +1,27 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct VertexIn {
+    float3 position [[attribute(0)]];
+    float3 color [[attribute(1)]];
+};
+
+struct VertexOut {
+    float4 position [[position]];
+    float3 color;
+};
+
+vertex VertexOut vertex_main(const device VertexIn* vertices [[buffer(0)]],
+                            uint vertexId [[vertex_id]]) {
+    VertexOut out;
+    VertexIn in = vertices[vertexId];
+    
+    out.position = float4(in.position, 1.0);
+    out.color = in.color;
+    
+    return out;
+}
+
+fragment float4 fragment_main(VertexOut in [[stage_in]]) {
+    return float4(in.color, 1.0);
+}


### PR DESCRIPTION
## Summary
- Add a new Metal-based triangle rendering application written in Swift
- Implements RGB vertex coloring (red, green, blue vertices)
- Uses native macOS Metal graphics API with Cocoa windowing
- Includes proper vertex structure and shader pipeline setup

## Files Added
- `src/apps/metal_triangle.swift` - Main Swift application with Metal rendering
- `src/apps/shaders.metal` - Metal shading language vertex and fragment shaders
- `src/apps/Info.plist` - macOS app bundle configuration  
- Updated `src/apps/CMakeLists.txt` with build instructions

## Test plan
- [x] Compile the Swift Metal app: `swiftc -o metal_triangle metal_triangle.swift -framework Cocoa -framework Metal -framework MetalKit`
- [x] Run the app: `./metal_triangle`
- [x] Verify triangle displays with correct RGB vertex colors
- [x] Ensure existing CMake build system continues to work for C++ components

🤖 Generated with [Claude Code](https://claude.ai/code)