### PR TITLE
Add checkerboard background texture to raytracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 [![CI](https://github.com/timthirion/Quasi/actions/workflows/ci.yml/badge.svg)](https://github.com/timthirion/Quasi/actions/workflows/ci.yml)
 
-A rendering system built on top of Google's Dawn WebGPU implementation and GLFW for windowing.
+Something of a renderer ...
+
+Disclaimer: this entire repository is ViBe-CoDeD with Claude Code.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,10 +19,17 @@ add_library(io INTERFACE
     io/PPMWriter.h
 )
 
+add_library(materials INTERFACE
+    materials/Texture.h
+    materials/CheckerboardTexture.h
+)
+
 target_include_directories(geometry PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(radiometry INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(io INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(materials INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Set up library dependencies
 target_link_libraries(radiometry INTERFACE geometry)
 target_link_libraries(io INTERFACE radiometry)
+target_link_libraries(materials INTERFACE radiometry)

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(test_app PRIVATE glfw)
 
 # Raytracer app
 add_executable(rt rt.cpp)
-target_link_libraries(rt PRIVATE geometry radiometry io)
+target_link_libraries(rt PRIVATE geometry radiometry io materials)
 target_compile_features(rt PRIVATE cxx_std_23)
 
 # Metal Triangle App - build separately with: swiftc -o metal_triangle metal_triangle.swift -framework Cocoa -framework Metal -framework MetalKit

--- a/src/apps/rt.cpp
+++ b/src/apps/rt.cpp
@@ -1,5 +1,6 @@
 #include "../geometry/geometry.h"
 #include "../io/PPMWriter.h"
+#include "../materials/CheckerboardTexture.h"
 #include "../radiometry/Camera.h"
 #include "../radiometry/Color.h"
 #include <iostream>
@@ -9,6 +10,7 @@
 using namespace Q::geometry;
 using namespace Q::radiometry;
 using namespace Q::io;
+using namespace Q::materials;
 
 struct ColoredSphere {
   Sphere sphere;
@@ -17,11 +19,64 @@ struct ColoredSphere {
   ColoredSphere(const Sphere &s, const Color &c) : sphere(s), color(c) {}
 };
 
+struct TexturedTriangle {
+  Triangle triangle;
+  Vec3 uv0, uv1, uv2; // UV coordinates for each vertex (z component unused)
+  CheckerboardTexture *texture;
+
+  TexturedTriangle(const Triangle &tri, const Vec3 &uv0, const Vec3 &uv1, const Vec3 &uv2,
+                   CheckerboardTexture *tex)
+      : triangle(tri), uv0(uv0), uv1(uv1), uv2(uv2), texture(tex) {}
+};
+
 class Scene {
 private:
   std::vector<ColoredSphere> spheres;
+  std::vector<TexturedTriangle> background_triangles;
+  CheckerboardTexture background_texture;
 
 public:
+  Scene() : background_texture(Color(1.0f, 1.0f, 1.0f), Color(0.0f, 0.0f, 0.0f), 6, 8) {
+    // Create background quad at the camera frustum's far plane
+    // Camera: 45° FOV, aspect ratio 4:3, positioned at origin looking down -Z
+    float far_distance = 20.0f; // Far plane distance
+    float fov_radians = 45.0f * M_PI / 180.0f;
+    float aspect_ratio = 800.0f / 600.0f; // 4:3
+
+    // Calculate quad dimensions slightly larger than camera frustum to avoid edge precision issues
+    float half_height = std::tan(fov_radians / 2.0f) * far_distance;
+    float half_width = half_height * aspect_ratio;
+
+    // Make quad slightly larger to ensure all edge rays hit
+    float margin = 0.01f; // Small margin to avoid edge precision issues
+    half_width += margin;
+    half_height += margin;
+
+    float quad_z = -far_distance;
+
+    // Define quad vertices slightly larger than camera frustum
+    Vec3 bottom_left(-half_width, -half_height, quad_z);
+    Vec3 bottom_right(half_width, -half_height, quad_z);
+    Vec3 top_left(-half_width, half_height, quad_z);
+    Vec3 top_right(half_width, half_height, quad_z);
+
+    // UV coordinates [0,1] × [0,1] for the quad
+    // Use small negative/positive margins to ensure texture coverage
+    float uv_margin = -0.005f; // Negative margin to slightly extend UV coverage
+    Vec3 uv_bl(uv_margin, uv_margin, 0.0f);
+    Vec3 uv_br(1.0f - uv_margin, uv_margin, 0.0f);
+    Vec3 uv_tl(uv_margin, 1.0f - uv_margin, 0.0f);
+    Vec3 uv_tr(1.0f - uv_margin, 1.0f - uv_margin, 0.0f);
+
+    // First triangle: bottom-left, bottom-right, top-left
+    background_triangles.emplace_back(Triangle(bottom_left, bottom_right, top_left), uv_bl, uv_br,
+                                      uv_tl, &background_texture);
+
+    // Second triangle: bottom-right, top-right, top-left
+    background_triangles.emplace_back(Triangle(bottom_right, top_right, top_left), uv_br, uv_tr,
+                                      uv_tl, &background_texture);
+  }
+
   void add_sphere(const Sphere &sphere, const Color &color) { spheres.emplace_back(sphere, color); }
 
   Color trace_ray(const Ray &ray) const {
@@ -29,6 +84,7 @@ public:
     Color hit_color;
     bool hit_anything = false;
 
+    // Check sphere intersections
     for (const auto &colored_sphere : spheres) {
       auto result = ray_sphere_intersection(ray, colored_sphere.sphere);
       if (result.has_value()) {
@@ -42,15 +98,35 @@ public:
       }
     }
 
+    // Check background triangle intersections (only if no sphere hit)
+    if (!hit_anything) {
+      for (const auto &textured_triangle : background_triangles) {
+        auto result = ray_triangle_intersection(ray, textured_triangle.triangle);
+        if (result.has_value() && result->hit) {
+          float t = result->t;
+          if (t > 0.001f && t < closest_t) {
+            closest_t = t;
+
+            // Interpolate UV coordinates using barycentric coordinates
+            Vec3 bary = result->barycentric;
+            float u = bary.x * textured_triangle.uv0.x + bary.y * textured_triangle.uv1.x +
+                      bary.z * textured_triangle.uv2.x;
+            float v = bary.x * textured_triangle.uv0.y + bary.y * textured_triangle.uv1.y +
+                      bary.z * textured_triangle.uv2.y;
+
+            hit_color = textured_triangle.texture->sample(u, v);
+            hit_anything = true;
+          }
+        }
+      }
+    }
+
     if (hit_anything) {
       return hit_color;
     }
 
-    // Background color (light blue gradient)
-    Vec3 unit_direction = ray.direction.get_normalized();
-    float t = 0.5f * (unit_direction.y + 1.0f);
-    return Color((1.0f - t) * 1.0f + t * 0.5f, // White to light blue
-                 (1.0f - t) * 1.0f + t * 0.7f, (1.0f - t) * 1.0f + t * 1.0f);
+    // Fallback background color (should rarely be reached)
+    return Color(0.2f, 0.2f, 0.2f); // Dark gray
   }
 };
 

--- a/src/materials/CheckerboardTexture.h
+++ b/src/materials/CheckerboardTexture.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "../radiometry/Color.h"
+#include "Texture.h"
+#include <cmath>
+
+namespace Q::materials {
+
+  /**
+   * A checkerboard texture that alternates between two colors in a grid pattern.
+   */
+  class CheckerboardTexture : public Texture {
+  private:
+    Q::radiometry::Color color1;
+    Q::radiometry::Color color2;
+    int rows;
+    int columns;
+
+  public:
+    /**
+     * Create a checkerboard texture.
+     * @param color1 First color of the checkerboard
+     * @param color2 Second color of the checkerboard
+     * @param rows Number of rows in the checkerboard
+     * @param columns Number of columns in the checkerboard
+     */
+    CheckerboardTexture(const Q::radiometry::Color &color1, const Q::radiometry::Color &color2,
+                        int rows, int columns)
+        : color1(color1), color2(color2), rows(rows), columns(columns) {}
+
+    /**
+     * Sample the checkerboard texture at the given UV coordinates.
+     * @param u Horizontal texture coordinate (0-1)
+     * @param v Vertical texture coordinate (0-1)
+     * @return Color at the specified UV coordinates
+     */
+    Q::radiometry::Color sample(float u, float v) const override {
+      // Wrap UV coordinates to [0,1) range (ensure we never hit exactly 1.0)
+      u = u - std::floor(u);
+      v = v - std::floor(v);
+      if (u >= 1.0f)
+        u = 0.0f;
+      if (v >= 1.0f)
+        v = 0.0f;
+
+      // Convert UV to grid coordinates
+      int grid_u = static_cast<int>(u * columns);
+      int grid_v = static_cast<int>(v * rows);
+
+      // Ensure grid coordinates are within bounds
+      grid_u = std::max(0, std::min(grid_u, columns - 1));
+      grid_v = std::max(0, std::min(grid_v, rows - 1));
+
+      // Determine checkerboard pattern (alternating colors)
+      bool is_even = (grid_u + grid_v) % 2 == 0;
+      return is_even ? color1 : color2;
+    }
+
+    // Getters for inspection/testing
+    const Q::radiometry::Color &get_color1() const { return color1; }
+    const Q::radiometry::Color &get_color2() const { return color2; }
+    int get_rows() const { return rows; }
+    int get_columns() const { return columns; }
+  };
+
+} // namespace Q::materials

--- a/src/materials/Texture.h
+++ b/src/materials/Texture.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../radiometry/Color.h"
+
+namespace Q::materials {
+
+  /**
+   * Abstract base class for texture sampling.
+   * Textures provide color values at given UV coordinates.
+   */
+  class Texture {
+  public:
+    virtual ~Texture() = default;
+
+    /**
+     * Sample the texture at the given UV coordinates.
+     * @param u Horizontal texture coordinate (typically 0-1)
+     * @param v Vertical texture coordinate (typically 0-1)
+     * @return Color at the specified UV coordinates
+     */
+    virtual Q::radiometry::Color sample(float u, float v) const = 0;
+  };
+
+} // namespace Q::materials

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,10 +4,12 @@ add_executable(quasi_tests
     test_basic.cpp
     test_ray_triangle_intersection.cpp
     test_ray_sphere_intersection.cpp
+    test_checkerboard_texture.cpp
 )
 target_link_libraries(quasi_tests PRIVATE 
     Catch2::Catch2WithMain
     geometry
+    materials
 )
 target_compile_features(quasi_tests PRIVATE cxx_std_23)
 

--- a/tests/test_checkerboard_texture.cpp
+++ b/tests/test_checkerboard_texture.cpp
@@ -1,0 +1,166 @@
+#include "../src/materials/CheckerboardTexture.h"
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace Q::materials;
+using namespace Q::radiometry;
+
+TEST_CASE("CheckerboardTexture Tests", "[materials][texture][checkerboard]") {
+
+  SECTION("Basic checkerboard pattern with 2x2 grid") {
+    Color white(1.0f, 1.0f, 1.0f);
+    Color black(0.0f, 0.0f, 0.0f);
+    CheckerboardTexture texture(white, black, 2, 2);
+
+    // Test corners - should alternate
+    Color top_left = texture.sample(0.0f, 0.0f);
+    Color top_right = texture.sample(0.99f, 0.0f);
+    Color bottom_left = texture.sample(0.0f, 0.99f);
+    Color bottom_right = texture.sample(0.99f, 0.99f);
+
+    REQUIRE(top_left.r == Catch::Approx(1.0f));     // white
+    REQUIRE(top_right.r == Catch::Approx(0.0f));    // black
+    REQUIRE(bottom_left.r == Catch::Approx(0.0f));  // black
+    REQUIRE(bottom_right.r == Catch::Approx(1.0f)); // white
+  }
+
+  SECTION("Checkerboard pattern with different colors") {
+    Color red(1.0f, 0.0f, 0.0f);
+    Color blue(0.0f, 0.0f, 1.0f);
+    CheckerboardTexture texture(red, blue, 2, 2);
+
+    Color sample1 = texture.sample(0.25f, 0.25f); // First quadrant
+    Color sample2 = texture.sample(0.75f, 0.25f); // Second quadrant
+
+    REQUIRE(sample1.r == Catch::Approx(1.0f)); // red
+    REQUIRE(sample1.b == Catch::Approx(0.0f));
+    REQUIRE(sample2.r == Catch::Approx(0.0f)); // blue
+    REQUIRE(sample2.b == Catch::Approx(1.0f));
+  }
+
+  SECTION("UV coordinates wrapping behavior") {
+    Color white(1.0f, 1.0f, 1.0f);
+    Color black(0.0f, 0.0f, 0.0f);
+    CheckerboardTexture texture(white, black, 2, 2);
+
+    // Test that UV coordinates wrap around
+    Color sample1 = texture.sample(0.0f, 0.0f);
+    Color sample2 = texture.sample(1.0f, 1.0f); // Should wrap to (0,0)
+    Color sample3 = texture.sample(2.5f, 3.7f); // Should wrap to (0.5, 0.7)
+
+    REQUIRE(sample1.r == sample2.r);
+    REQUIRE(sample1.g == sample2.g);
+    REQUIRE(sample1.b == sample2.b);
+
+    Color reference = texture.sample(0.5f, 0.7f);
+    REQUIRE(sample3.r == reference.r);
+  }
+
+  SECTION("Different grid dimensions") {
+    Color color1(0.2f, 0.4f, 0.6f);
+    Color color2(0.8f, 0.6f, 0.4f);
+    CheckerboardTexture texture(color1, color2, 4, 8);
+
+    // Test that we get different patterns with different grid sizes
+    Color sample_center = texture.sample(0.5f, 0.5f);
+    Color sample_quarter = texture.sample(0.25f, 0.25f);
+
+    // These should be different colors due to the 4x8 grid
+    bool colors_different = (sample_center.r != sample_quarter.r) ||
+                            (sample_center.g != sample_quarter.g) ||
+                            (sample_center.b != sample_quarter.b);
+    REQUIRE(colors_different);
+  }
+
+  SECTION("Getter methods work correctly") {
+    Color red(1.0f, 0.0f, 0.0f);
+    Color green(0.0f, 1.0f, 0.0f);
+    CheckerboardTexture texture(red, green, 3, 5);
+
+    REQUIRE(texture.get_color1().r == Catch::Approx(1.0f));
+    REQUIRE(texture.get_color2().g == Catch::Approx(1.0f));
+    REQUIRE(texture.get_rows() == 3);
+    REQUIRE(texture.get_columns() == 5);
+  }
+
+  SECTION("Edge cases with small grid") {
+    Color white(1.0f, 1.0f, 1.0f);
+    Color black(0.0f, 0.0f, 0.0f);
+    CheckerboardTexture texture(white, black, 1, 1);
+
+    // With 1x1 grid, everything should be the same color (color1)
+    Color sample1 = texture.sample(0.0f, 0.0f);
+    Color sample2 = texture.sample(0.5f, 0.5f);
+    Color sample3 = texture.sample(0.99f, 0.99f);
+
+    REQUIRE(sample1.r == sample2.r);
+    REQUIRE(sample2.r == sample3.r);
+    REQUIRE(sample1.r == Catch::Approx(1.0f)); // Should be color1 (white)
+  }
+
+  SECTION("Checkerboard pattern consistency") {
+    Color white(1.0f, 1.0f, 1.0f);
+    Color black(0.0f, 0.0f, 0.0f);
+    CheckerboardTexture texture(white, black, 4, 4);
+
+    // Test that adjacent squares have different colors
+    Color center_square = texture.sample(0.375f, 0.375f); // Center of (1,1) square
+    Color right_square = texture.sample(0.625f, 0.375f);  // Center of (2,1) square
+    Color below_square = texture.sample(0.375f, 0.625f);  // Center of (1,2) square
+
+    // Adjacent squares should have different colors
+    bool right_different = (center_square.r != right_square.r);
+    bool below_different = (center_square.r != below_square.r);
+
+    REQUIRE(right_different);
+    REQUIRE(below_different);
+  }
+
+  SECTION("Boundary conditions") {
+    Color red(1.0f, 0.0f, 0.0f);
+    Color blue(0.0f, 0.0f, 1.0f);
+    CheckerboardTexture texture(red, blue, 3, 3);
+
+    // Test exactly at boundaries
+    Color at_zero = texture.sample(0.0f, 0.0f);
+    Color at_third = texture.sample(1.0f / 3.0f, 1.0f / 3.0f);
+    Color at_two_thirds = texture.sample(2.0f / 3.0f, 2.0f / 3.0f);
+
+    // These should alternate in checkerboard pattern
+    REQUIRE(at_zero.r == Catch::Approx(1.0f));       // red (0,0) -> sum=0 (even)
+    REQUIRE(at_third.r == Catch::Approx(1.0f));      // red (1,1) -> sum=2 (even)
+    REQUIRE(at_two_thirds.r == Catch::Approx(1.0f)); // red (2,2) -> sum=4 (even)
+  }
+
+  SECTION("Negative UV coordinates") {
+    Color white(1.0f, 1.0f, 1.0f);
+    Color black(0.0f, 0.0f, 0.0f);
+    CheckerboardTexture texture(white, black, 2, 2);
+
+    // Negative coordinates should wrap properly
+    Color positive = texture.sample(0.25f, 0.25f);
+    Color negative = texture.sample(-0.75f, -0.75f); // Should wrap to (0.25, 0.25)
+
+    REQUIRE(positive.r == negative.r);
+    REQUIRE(positive.g == negative.g);
+    REQUIRE(positive.b == negative.b);
+  }
+
+  SECTION("Non-square checkerboards") {
+    Color yellow(1.0f, 1.0f, 0.0f);
+    Color purple(1.0f, 0.0f, 1.0f);
+    CheckerboardTexture texture(yellow, purple, 2, 6); // 2 rows, 6 columns
+
+    // Sample different parts of the non-square grid
+    Color sample1 = texture.sample(0.08f, 0.25f); // First row, first column (0,0)
+    Color sample2 = texture.sample(0.25f, 0.25f); // First row, second column (1,0)
+    Color sample3 = texture.sample(0.08f, 0.75f); // Second row, first column (0,1)
+
+    // Should alternate properly (compare green component since yellow has g=1, purple has g=0)
+    bool row_alternates = (sample1.g != sample2.g);
+    bool col_alternates = (sample1.g != sample3.g);
+
+    REQUIRE(row_alternates);
+    REQUIRE(col_alternates);
+  }
+}


### PR DESCRIPTION
## Summary
- Add abstract Texture base class and CheckerboardTexture implementation
- Replace simple background color with textured background quad positioned at camera frustum far plane
- Add comprehensive texture tests with edge cases and UV coordinate validation

## Test plan
- [x] Build system successfully compiles new texture classes
- [x] All existing tests continue to pass (193 assertions)
- [x] New texture tests validate checkerboard pattern and UV coordinates
- [x] Raytracer successfully renders 800x600 image with checkerboard background

🤖 Generated with [Claude Code](https://claude.ai/code)