### PR TITLE
Add .idea/ to gitignore for JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 # Claude Code configuration
 .claude/
 
+# JetBrains IDEs (IntelliJ, CLion, etc.)
+.idea/
+
 # Metal build artifacts
 *.metallib
 *.air


### PR DESCRIPTION
## Summary
Quick fix to add `.idea/` folder to gitignore to prevent JetBrains IDE settings from being tracked in git.

## What this does
- Adds `.idea/` to `.gitignore` 
- Prevents IDE-specific configuration files from being committed
- Keeps the repository clean for all developers regardless of IDE choice

## Why needed
The `.idea/` folder contains:
- User-specific IDE preferences
- Environment-specific settings
- Frequently changing metadata

These should not be version controlled as they vary between developers and create unnecessary noise in commits.

🤖 Generated with [Claude Code](https://claude.ai/code)